### PR TITLE
Updated Linux specific files to match the latest revision

### DIFF
--- a/N3888_RefImpl/src/display_surface-xcb.cpp
+++ b/N3888_RefImpl/src/display_surface-xcb.cpp
@@ -79,7 +79,7 @@ display_surface::display_surface(int preferredWidth, int preferredHeight, experi
 	, _Native_surface(nullptr, &cairo_surface_destroy)
 	, _Native_context(nullptr, &cairo_destroy)
 	, _Letterbox_brush()
-	, _Default_brush(bgra_color::transparent_black()) {
+	, _Default_brush(rgba_color::transparent_black) {
 	if (preferredDisplayWidth <= 0 || preferredDisplayHeight <= 0 || preferredWidth <= 0 || preferredHeight <= 0 || preferredFormat == experimental::io2d::format::invalid) {
 		throw invalid_argument("Invalid parameter.");
 	}

--- a/N3888_RefImpl/src/display_surface-xlib.cpp
+++ b/N3888_RefImpl/src/display_surface-xlib.cpp
@@ -193,7 +193,7 @@ display_surface::display_surface(int preferredWidth, int preferredHeight, experi
 	, _Native_surface(nullptr, &cairo_surface_destroy)
 	, _Native_context(nullptr, &cairo_destroy)
 	, _Letterbox_brush()
-	, _Default_brush(bgra_color::transparent_black()) {
+	, _Default_brush(rgba_color::transparent_black) {
 	if (preferredDisplayWidth <= 0 || preferredDisplayHeight <= 0 || preferredWidth <= 0 || preferredHeight <= 0 || preferredFormat == experimental::io2d::format::invalid) {
 		throw invalid_argument("Invalid parameter.");
 	}
@@ -241,6 +241,7 @@ display_surface::~display_surface() {
 			_Display.swap(emptyDisplay);
 		}
 	}
+}
 
 int display_surface::begin_show() {
 	Display* display = _Display.get();


### PR DESCRIPTION
This pull request changes `bgra_color` to `rgba_color` for `xlib` and `xcb` `display_source` files that were not updated last time. Also fixes a missing closing bracket for the destructor of `display_source`.